### PR TITLE
Pesquisar usuario id api

### DIFF
--- a/raromdb-cypress-api/cypress/e2e/api/users/pesquisaUsuarioID.cy.js
+++ b/raromdb-cypress-api/cypress/e2e/api/users/pesquisaUsuarioID.cy.js
@@ -1,0 +1,246 @@
+import { fakerPT_BR, faker } from '@faker-js/faker';
+
+
+describe('Cenários de testes de Pesquisar usuário por ID', () => {
+    var nome = 'Zillaell';
+    var email = fakerPT_BR.internet.email().toLowerCase();;
+    var senha = '123456';
+    var type;
+    var token;
+    var token1;
+    var id;
+    var id1;
+    var id2;
+    var emaill;
+    var nomex = 'Mockador';
+
+    beforeEach(()=>{
+        emaill = fakerPT_BR.internet.email().toLowerCase();
+        cy.registroUser(nomex, emaill, senha).then((response)=>{
+            id = response.body.id;
+            type= response.body.type;
+        })
+    })
+    afterEach(()=>{
+        cy.registroUser('m'+ nome, 'mock'+ email, senha).then((response)=>{
+            id2 = response.body.id;
+        })
+        cy.logarUser('mock'+ email, senha).then((usuario) => {
+            token = usuario.body.accessToken;
+            cy.promoverAdmin(token);
+            cy.deletaUsuario(id, token).then((response)=>{
+                expect(response.body).to.be.empty;
+                expect(response.status).to.eq(204);
+            });
+            cy.deletaUsuario(id1, token).then((response)=>{
+                expect(response.body).to.be.empty;
+                expect(response.status).to.eq(204);
+            });
+            cy.deletaUsuario(id2, token).then((response)=>{
+                expect(response.body).to.be.empty;
+                expect(response.status).to.eq(204);
+            });
+        })
+    })
+    context('Cenários de Pesquisar usuário por ID com sucesso', () => {
+        it('deve ser possível acessar a Pesquisar usuário por ID sendo um usuário do tipo admin',()=>{
+            cy.registroUser(nome, email, senha).then((Usuario)=>{
+                id1 = Usuario.body.id;
+                cy.logarUser( email, senha).then((usuario) => {
+                    token1 = usuario.body.accessToken;
+                    cy.promoverAdmin(token1);
+                    cy.request({
+                        method: 'GET',
+                        url: '/api/users/' + id,
+                        headers: {
+                            Authorization: 'Bearer ' + token1
+                        }
+                    }).then((response) => {
+                        expect(response.status).to.be.eq(200)
+                        expect(response.body).to.have.property('id');
+                        expect(response.body).to.have.property('name');
+                        expect(response.body).to.have.property('type');
+                        expect(response.body).to.have.property('email');
+                        expect(response.body).to.have.property('active');
+                        expect(response.body.id).to.eq(id);
+                        expect(response.body.name).to.eq(nomex);
+                        expect(response.body.email).to.eq(emaill);
+                        expect(response.body.type).to.eq(type);
+                        expect(response.body.id).to.not.eq(id1);    
+                    })
+                })
+            })
+        })
+        it('deve ser possível achar o proprio usuário na pesquisa por ID sendo um usuário do tipo admini',()=>{
+            cy.registroUser(nome, email, senha).then((Usuario)=>{
+                id1 = Usuario.body.id;
+                type = Usuario.body.type;
+                cy.logarUser(email, senha).then((usuario) => {
+                    token1 = usuario.body.accessToken;
+                    cy.promoverAdmin(token1);
+                    cy.request({
+                        method: 'GET',
+                        url: '/api/users/' + id1,
+                        headers: {
+                            Authorization: 'Bearer ' + token1
+                        }
+                    }).then((response) => {
+                        expect(response.status).to.be.eq(200)
+                        expect(response.body).to.have.property('id');
+                        expect(response.body).to.have.property('name');
+                        expect(response.body).to.have.property('type');
+                        expect(response.body).to.have.property('email');
+                        expect(response.body).to.have.property('active');
+                        expect(response.body.id).to.eq(id1);
+                        expect(response.body.name).to.eq(nome);
+                        expect(response.body.email).to.eq(email);
+                        expect(response.body.type).to.eq(1);
+                        expect(response.body.id).to.not.eq(id);    
+                    })
+                })
+            })
+        })
+        it('deve ser possível achar o proprio usuário na pesquisa por ID sendo um usuário do tipo critico',()=>{
+            cy.registroUser(nome, email, senha).then((Usuario)=>{
+                id1 = Usuario.body.id;
+                type = Usuario.body.type;
+                cy.logarUser(email, senha).then((usuario) => {
+                    token1 = usuario.body.accessToken;
+                    cy.promoverCritico(token1);
+                    cy.request({
+                        method: 'GET',
+                        url: '/api/users/' + id1,
+                        headers: {
+                            Authorization: 'Bearer ' + token1
+                        }
+                    }).then((response) => {
+                        expect(response.status).to.be.eq(200)
+                        expect(response.body).to.have.property('id');
+                        expect(response.body).to.have.property('name');
+                        expect(response.body).to.have.property('type');
+                        expect(response.body).to.have.property('email');
+                        expect(response.body).to.have.property('active');
+                        expect(response.body.id).to.eq(id1);
+                        expect(response.body.name).to.eq(nome);
+                        expect(response.body.email).to.eq(email);
+                        expect(response.body.type).to.eq(2);
+                        expect(response.body.id).to.not.eq(id);    
+                    })
+                })
+            })
+        })
+        it('deve ser possível achar o proprio usuário na pesquisa por ID sendo um usuário do tipo comum',()=>{
+            cy.registroUser(nome, email, senha).then((Usuario)=>{
+                id1 = Usuario.body.id;
+                type = Usuario.body.type;
+                cy.logarUser(email, senha).then((usuario) => {
+                    token1 = usuario.body.accessToken;
+                    cy.request({
+                        method: 'GET',
+                        url: '/api/users/' + id1,
+                        headers: {
+                            Authorization: 'Bearer ' + token1
+                        }
+                    }).then((response) => {
+                        expect(response.status).to.be.eq(200)
+                        expect(response.body).to.have.property('id');
+                        expect(response.body).to.have.property('name');
+                        expect(response.body).to.have.property('type');
+                        expect(response.body).to.have.property('email');
+                        expect(response.body).to.have.property('active');
+                        expect(response.body.id).to.eq(id1);
+                        expect(response.body.name).to.eq(nome);
+                        expect(response.body.email).to.eq(email);
+                        expect(response.body.type).to.eq(0);
+                        expect(response.body.id).to.not.eq(id);    
+                    })
+                })
+            })
+        })
+        it('deve ser possível o retorno 200 mesmo sem achar outros usuário na pesquisa por ID sendo um usuário do tipo admin',()=>{
+            cy.registroUser(nome, email, senha).then((Usuario)=>{
+                id1 = Usuario.body.id;
+                cy.logarUser(email, senha).then((usuario) => {
+                    token1 = usuario.body.accessToken;
+                    cy.promoverAdmin(token1);
+                    cy.request({
+                        method: 'GET',
+                        url: '/api/users/' + 0,
+                        headers: {
+                            Authorization: 'Bearer ' + token1
+                        }
+                    }).then((response) => {
+                        expect(response.status).to.be.eq(200)
+                        expect(response.body).to.be.empty; 
+                    })
+                })
+            })
+        })
+    })
+    describe('Cenários de BAD REQUEST',()=>{
+        it('não deve ser possível acessar o Pesquisar outro usuário por ID sendo um usuário do tipo comum',()=>{
+            cy.registroUser(nome,'1'+ email, senha).then((Usuario)=>{
+                id1= Usuario.body.id;
+            })
+            cy.logarUser('1'+ email, senha).then((usuario) => {
+                token1 = usuario.body.accessToken;
+                cy.request({
+                    method: 'GET',
+                    url: '/api/users/' + id,
+                    headers: {
+                        Authorization: 'Bearer ' + token1
+                    },
+                    failOnStatusCode: false
+                }).then((response) => {
+                    expect(response.status).to.be.eq(403)
+                    expect(response.body).to.be.an('object');
+                    cy.fixture('forbidden.json').then(function (forbidden) {
+                        expect(response.body).to.deep.eq(forbidden)
+                    });
+                })
+            })
+        })
+        it('não deve ser possível acessar o Pesquisar outro usuários por ID sendo um usuário do tipo crítico',()=>{
+            cy.registroUser(nome,'1'+ email, senha).then((Usuario)=>{
+                id1 = Usuario.body.id;
+            })
+            cy.logarUser('1'+ email, senha).then((usuario) => {
+                token1 = usuario.body.accessToken;
+                cy.promoverCritico(token1);
+                cy.request({
+                    method: 'GET',
+                    url: '/api/users/' + id,
+                    headers: {
+                        Authorization: 'Bearer ' + token1
+                    },
+                    failOnStatusCode: false
+                }).then((response) => {
+                    expect(response.status).to.be.eq(403)
+                    expect(response.body).to.be.an('object');
+                    cy.fixture('forbidden.json').then(function (forbidden) {
+                        expect(response.body).to.deep.eq(forbidden)
+                    });
+                })
+            })
+        })
+        it('não deve ser possível acessar o Pesquisar outro usuario por id sem estar autenticado',()=>{
+            cy.registroUser(nome, email, senha).then((Usuario)=>{
+                id1 = Usuario.body.id;
+                cy.request({
+                    method: 'GET',
+                    url: '/api/users/' + id,
+                    headers: {
+                        Authorization: 'Bearer ' + token1 
+                    },
+                    failOnStatusCode: false
+                }).then((response) => {
+                    expect(response.status).to.be.eq(401)
+                    expect(response.body).to.be.an('object');
+                    cy.fixture('unauthorized.json').then(function (unauthorized) {
+                        expect(response.body).to.deep.eq(unauthorized)
+                    });
+                })
+            })
+        })
+    })
+})

--- a/raromdb-cypress-api/cypress/e2e/api/users/promoverAdmin.cy.js
+++ b/raromdb-cypress-api/cypress/e2e/api/users/promoverAdmin.cy.js
@@ -1,0 +1,124 @@
+import { fakerPT_BR, faker } from '@faker-js/faker';
+
+describe('Cenários de testes de tornar usuário Administrador', () => {
+    var nome = 'Zillaell';
+    var email = fakerPT_BR.internet.email().toLowerCase();;
+    var senha = '123456';
+    var token;
+    var tokenM;
+    var id;
+    var idM;
+    var type;
+    var idFilme;
+    var idFilmeM;
+    context('Cenários de Tornar Admin com sucesso', () => {
+
+        it('deve ser possível tornar usuario comum em admin', () => {
+            cy.registroUser(nome, '1' + email, senha);
+            cy.logarUser('1' + email, senha).then((usuario) => {
+                token = usuario.body.accessToken
+                cy.request({
+                    method: 'PATCH',
+                    url: '/api/users/admin',
+                    headers: {
+                        Authorization: 'Bearer ' + token
+                    }
+                }).then((response) => {
+                    expect(response.status).to.be.eq(204)
+                })
+            })
+        })
+        it('deve ser possível tornar usuario crítico em admim', () => {
+            cy.registroUser(nome, email, senha);
+            cy.logarUser(email, senha).then((usuario) => {
+                token = usuario.body.accessToken
+                cy.promoverCritico(token)
+                cy.request({
+                    method: 'PATCH',
+                    url: '/api/users/admin',
+                    headers: {
+                        Authorization: 'Bearer ' + token
+                    }
+                }).then((response) => {
+                    expect(response.status).to.be.eq(204)
+                })
+            })
+        })
+        it('deve ser possível identificar a review de um usuario admin', () => {
+            cy.registroUser(nome, '2' + email, senha).then((Usuario) => {
+                id = Usuario.body.id;
+            })
+            cy.logarUser('2' + email, senha).then((usuario) => {
+                token = usuario.body.accessToken;
+                cy.promoverAdmin(token);
+                cy.criarFilme(token).then((idFilmeNovo) => {
+                    idFilme = idFilmeNovo;
+                    cy.criarReview(token, idFilme).then((response) => {
+                        expect(response.status).to.eq(201);
+                    });
+                    cy.buscarFilmeId(idFilme, token).then((response) => {
+                        expect(response.body.id).to.eq(idFilme);
+                        expect(response.body.reviews[0].user.id).to.eq(id);
+                        expect(response.body.reviews[0].user.type).to.eq(1);
+                        expect(response.body.reviews[0]).to.have.property('user');
+                    })
+                })
+            })
+        })
+        it('deve ser possível identificar a review de um usuario comum mesmo mudando posteriormente para admin', () => {
+            cy.registroUser(nome, '3' + email, senha).then((Usuario) => {
+                id = Usuario.body.id;
+            })
+            cy.logarUser('3' + email, senha).then((usuario) => {
+                token = usuario.body.accessToken;
+                cy.promoverAdmin(token);
+                cy.criarFilme(token).then((idFilmeNovo) => {
+                    idFilmeM = idFilmeNovo;
+                })
+            })
+            cy.registroUser(nome, '4' + email, senha).then((Usuario) => {
+                idM = Usuario.body.id;
+                type = Usuario.body.type;
+                cy.log(type);
+                cy.logarUser('4' + email, senha).then((usuario) => {
+                    tokenM = usuario.body.accessToken;
+                    cy.criarReview(tokenM, idFilmeM).then((response) => {
+                        expect(response.status).to.eq(201);
+                    });
+                    cy.promoverAdmin(tokenM);
+                    cy.request({
+                        method: 'GET',
+                        url: '/api/movies/' + idFilmeM,
+                        headers: {
+                            Authorization: 'Bearer ' + tokenM
+                        }
+                    }).then((response) => {
+                        expect(response.body.id).to.eq(idFilmeM);
+                        expect(response.body.reviews[0].user.id).to.eq(idM);
+                        expect(response.body.reviews[0].reviewType).to.eq(type);
+                    })
+                })
+            });
+        })
+    })
+    describe('Cenários de BAD REQUEST', () => {
+        it('dNão deve ser possível tornar usuario em admin sem que esteja autenticado', () => {
+            cy.registroUser(nome, '5' + email, senha);
+            cy.request({
+                method: 'PATCH',
+                url: '/api/users/admin',
+                headers: {
+                    Authorization: 'Bearer '
+                },
+                failOnStatusCode: false
+
+            }).then((response) => {
+                expect(response.status).to.be.eq(401)
+                expect(response.body).to.be.an('object');
+                cy.fixture('unauthorized.json').then(function (unauthorized) {
+                    expect(response.body).to.deep.eq(unauthorized)
+                });
+            })
+        })
+    })
+})


### PR DESCRIPTION
Funcionalidade: Pesquisar usuário por id

Contexto: o usuário deve ter acessado a funcionalidade

Cenário: deve ser possível achar outros usuário na pesquisa por ID sendo um usuário do tipo admin
  
Cenário: deve ser possível achar o próprio usuário na pesquisa por ID sendo um usuário do tipo critico

Cenário: deve ser possível achar o próprio usuário na pesquisa por ID sendo um usuário do tipo comum

Cenário: deve ser possível o retorno 200 mesmo sem achar outros usuário na pesquisa por ID sendo um usuário do tipo admin
 
Cenário: não deve ser possível acessar o Pesquisar outro próprio por id sendo um usuário do tipo comum

Cenário: não deve ser possível acessar o Pesquisar outro próprio por id sendo um usuário do tipo crítico

Cenário: não deve ser possível acessar o Pesquisar outro próprio por id sem estar autenticado
